### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mahotas/__init__.py
+++ b/mahotas/__init__.py
@@ -87,7 +87,7 @@ except ImportError: # pragma: no cover
     _,e,_ = sys.exc_info()
     from sys import stderr
     stderr.write('''\
-Could not import submodules (exact error was: %s).
+Could not import submodules (exact error was: {0!s}).
 
 There are many reasons for this error the most common one is that you have
 either not built the packages or have built (using `python setup.py build`) or
@@ -95,7 +95,7 @@ installed them (using `python setup.py install`) and then proceeded to test
 mahotas **without changing the current directory**.
 
 Try installing and then changing to another directory before importing mahotas.
-''' % e)
+'''.format(e))
 
 citation_text = '''
 If you use mahotas please cite

--- a/mahotas/_filters.py
+++ b/mahotas/_filters.py
@@ -18,7 +18,7 @@ modes = frozenset(mode2int.keys())
 
 def _checked_mode2int(mode, cval, fname):
     if mode not in modes:
-        raise ValueError('mahotas.%s: `mode` not in %s' % (fname, modes))
+        raise ValueError('mahotas.{0!s}: `mode` not in {1!s}'.format(fname, modes))
     if mode == 'constant' and cval != 0.:
         raise NotImplementedError('Please email mahotas developers to get this implemented.')
     return mode2int[mode]

--- a/mahotas/convolve.py
+++ b/mahotas/convolve.py
@@ -422,7 +422,7 @@ def gaussian_filter(array, sigma, order=0, mode='reflect', cval=0., out=None, ou
 def _wavelet_array(f, inline, func):
     f = _as_floating_point_array(f)
     if f.ndim != 2:
-        raise ValueError('mahotas.convolve.%s: Only works for 2D images' % func)
+        raise ValueError('mahotas.convolve.{0!s}: Only works for 2D images'.format(func))
     if not inline:
         return f.copy()
     return f
@@ -537,7 +537,7 @@ def haar(f, preserve_energy=True, inline=False):
         f /= 2.0
     return f
 
-_daubechies_codes = [('D%s' % ci) for ci in range(2,21,2)]
+_daubechies_codes = [('D{0!s}'.format(ci)) for ci in range(2,21,2)]
 def _daubechies_code(c):
     try:
         return _daubechies_codes.index(c)

--- a/mahotas/features/tas.py
+++ b/mahotas/features/tas.py
@@ -28,7 +28,7 @@ def _tas(img, thresh, margin):
         bins = _bins3
         saved = 27
     else:
-        raise ValueError('mahotas.tas: Cannot compute TAS for image of %s dimensions' % len(img.shape))
+        raise ValueError('mahotas.tas: Cannot compute TAS for image of {0!s} dimensions'.format(len(img.shape)))
 
     def _ctas(img):
         V = convolve(img.astype(np.uint8), M)

--- a/mahotas/features/texture.py
+++ b/mahotas/features/texture.py
@@ -405,7 +405,7 @@ def cooccurence(f, direction, output=None, symmetric=True):
     elif len(f.shape) == 3 and not (0 <= direction < 13):
         raise ValueError('mahotas.texture.cooccurence: `direction` {0} is not in range(13).'.format(direction))
     elif len(f.shape) not in (2,3):
-        raise ValueError('mahotas.texture.cooccurence: cannot handle images of %s dimensions.' % len(f.shape))
+        raise ValueError('mahotas.texture.cooccurence: cannot handle images of {0!s} dimensions.'.format(len(f.shape)))
 
     if output is None:
         mf = f.max()

--- a/mahotas/internal.py
+++ b/mahotas/internal.py
@@ -28,21 +28,20 @@ def _get_output(array, out, fname, dtype=None, output=None):
         dtype = array.dtype
     if output is not None:
         import warnings
-        warnings.warn('Using deprecated `output` argument in function `%s`. Please use `out` in the future. It has exactly the same meaning and it matches what numpy uses.' % fname, DeprecationWarning)
+        warnings.warn('Using deprecated `output` argument in function `{0!s}`. Please use `out` in the future. It has exactly the same meaning and it matches what numpy uses.'.format(fname), DeprecationWarning)
         if out is not None:
-            warnings.warn('Using both `out` and `output` in function `%s`.\nMahotas is going to ignore the `output` argument and use the `out` version exclusively.' % fname)
+            warnings.warn('Using both `out` and `output` in function `{0!s}`.\nMahotas is going to ignore the `output` argument and use the `out` version exclusively.'.format(fname))
         else:
             out = output
     if out is None:
         return np.empty(array.shape, dtype)
     if out.dtype != dtype:
         raise ValueError(
-            'mahotas.%s: `out` has wrong type (out.dtype is %s; expected %s)%s' %
-                (fname, out.dtype, dtype, detail))
+            'mahotas.{0!s}: `out` has wrong type (out.dtype is {1!s}; expected {2!s}){3!s}'.format(fname, out.dtype, dtype, detail))
     if out.shape != array.shape:
-        raise ValueError('mahotas.%s: `out` has wrong shape (got %s, while expecting %s)%s' % (fname, out.shape, array.shape, detail))
+        raise ValueError('mahotas.{0!s}: `out` has wrong shape (got {1!s}, while expecting {2!s}){3!s}'.format(fname, out.shape, array.shape, detail))
     if not out.flags.contiguous:
-        raise ValueError('mahotas.%s: `out` is not c-array%s' % (fname,detail))
+        raise ValueError('mahotas.{0!s}: `out` is not c-array{1!s}'.format(fname, detail))
     return out
 
 def _get_axis(array, axis, fname):
@@ -66,7 +65,7 @@ def _get_axis(array, axis, fname):
     if axis < 0:
         axis += len(array.shape)
     if not (0 <= axis < len(array.shape)):
-        raise ValueError('mahotas.%s: `axis` is out of bounds (maximum was %s, got %s)' % (fname, array.ndim, axis))
+        raise ValueError('mahotas.{0!s}: `axis` is out of bounds (maximum was {1!s}, got {2!s})'.format(fname, array.ndim, axis))
     return axis
 
 def _normalize_sequence(array, value, fname):
@@ -93,7 +92,7 @@ def _normalize_sequence(array, value, fname):
     except TypeError:
         return [value for s in array.shape]
     if len(value) != array.ndim:
-        raise ValueError('mahotas.%s: argument is sequence, but has wrong size (%s for an array of %s dimensions)' % (fname, len(value), array.ndim))
+        raise ValueError('mahotas.{0!s}: argument is sequence, but has wrong size ({1!s} for an array of {2!s} dimensions)'.format(fname, len(value), array.ndim))
     return value
 
 def _verify_is_floatingpoint_type(A, function_name):
@@ -110,7 +109,7 @@ def _verify_is_floatingpoint_type(A, function_name):
         Used for error messages
     '''
     if not np.issubdtype(A.dtype, np.float):
-        raise TypeError('mahotas.%s: This function only accepts floating-point types (passed array of type %s)' % (function_name, A.dtype))
+        raise TypeError('mahotas.{0!s}: This function only accepts floating-point types (passed array of type {1!s})'.format(function_name, A.dtype))
 
 def _verify_is_integer_type(A, function_name):
     '''
@@ -127,7 +126,7 @@ def _verify_is_integer_type(A, function_name):
     '''
     k = A.dtype.kind
     if k not in "iub": # integer, unsigned integer, boolean
-        raise TypeError('mahotas.%s: This function only accepts integer types (passed array of type %s)' % (function_name, A.dtype))
+        raise TypeError('mahotas.{0!s}: This function only accepts integer types (passed array of type {1!s})'.format(function_name, A.dtype))
 
 def _verify_is_nonnegative_integer_type(A, function_name):
     '''
@@ -171,8 +170,8 @@ def _as_floating_point_array(array):
 
 def _check_3(arr, funcname):
     if arr.ndim != 3 or arr.shape[2] != 3:
-        raise ValueError('mahotas.%s: this function expects an array of shape (h, w, 3), received an array of shape %s.' % (funcname, arr.shape))
+        raise ValueError('mahotas.{0!s}: this function expects an array of shape (h, w, 3), received an array of shape {1!s}.'.format(funcname, arr.shape))
 
 def _check_2(arr, funcname):
     if arr.ndim != 2:
-        raise ValueError('mahotas.%s: this function can only handle 2D arrays (passed array with shape %s).' % (funcname, arr.shape))
+        raise ValueError('mahotas.{0!s}: this function can only handle 2D arrays (passed array with shape {1!s}).'.format(funcname, arr.shape))

--- a/mahotas/interpolate.py
+++ b/mahotas/interpolate.py
@@ -43,11 +43,11 @@ from ._filters import mode2int, modes, _check_mode
 
 def _check_interpolate(array, order, funcname):
     if not (0 < order < 5):
-        raise ValueError('mahotas.interpolate.%s: spline order not supported' % funcname)
+        raise ValueError('mahotas.interpolate.{0!s}: spline order not supported'.format(funcname))
 
     array = np.asarray(array)
     if np.iscomplexobj(array):
-        raise TypeError('mahotas.interpolate.%s: Complex type not supported' % funcname)
+        raise TypeError('mahotas.interpolate.{0!s}: Complex type not supported'.format(funcname))
     return array
 
 def spline_filter1d(array, order=3, axis=-1, out=None, dtype=np.float64, output=None):

--- a/mahotas/io/freeimage.py
+++ b/mahotas/io/freeimage.py
@@ -221,7 +221,7 @@ else:
 
 @_functype(None, ctypes.c_int, ctypes.c_char_p)
 def _error_handler(fif, message):
-    raise RuntimeError('mahotas.freeimage: FreeImage error: %s' % message)
+    raise RuntimeError('mahotas.freeimage: FreeImage error: {0!s}'.format(message))
 
 _FI.FreeImage_SetOutputMessage(_error_handler)
 
@@ -308,7 +308,7 @@ class FI_TYPES(object):
                 extra_dims = [4]
             else:
                 raise ValueError(
-                    'mahotas.freeimage: cannot convert %d BPP bitmap' % bpp)
+                    'mahotas.freeimage: cannot convert {0:d} BPP bitmap'.format(bpp))
         else:
             extra_dims = cls.extra_dims[fi_type]
         return np.dtype(dtype), extra_dims + [w, h]
@@ -457,7 +457,7 @@ def read_multipage(filename, flags=0):
     ftype = _FI.FreeImage_GetFileType(_bytestr(filename), 0)
     if ftype == -1:
         raise ValueError(
-            'mahotas.freeimage: cannot determine type of file %s'%filename)
+            'mahotas.freeimage: cannot determine type of file {0!s}'.format(filename))
     create_new = False
     read_only = True
     keep_cache_in_memory = True
@@ -487,11 +487,11 @@ def _read_bitmap(filename, flags):
     ftype = _FI.FreeImage_GetFileType(_bytestr(filename), 0)
     if ftype == -1:
         raise ValueError(
-            'mahotas.freeimage: cannot determine type of file %s' % filename)
+            'mahotas.freeimage: cannot determine type of file {0!s}'.format(filename))
     bitmap = _FI.FreeImage_Load(ftype, _bytestr(filename), flags)
     if not bitmap:
         raise ValueError(
-            'mahotas.freeimage: could not load file %s' % filename)
+            'mahotas.freeimage: could not load file {0!s}'.format(filename))
     return bitmap
 
 
@@ -582,7 +582,7 @@ def write(array, filename, flags=0):
     ftype = _FI.FreeImage_GetFIFFromFilename(filename)
     if ftype == -1:
         raise ValueError(
-            'mahotas.freeimage: cannot determine type for %s' % filename)
+            'mahotas.freeimage: cannot determine type for {0!s}'.format(filename))
     bitmap, fi_type = _array_to_bitmap(array)
     try:
         if fi_type == FI_TYPES.FIT_BITMAP:
@@ -611,7 +611,7 @@ def write_multipage(arrays, filename, flags=0, keep_cache_in_memory=True):
     ftype = _FI.FreeImage_GetFIFFromFilename(_bytestr(filename))
     if ftype == -1:
         raise ValueError(
-            'mahotas.freeimage: cannot determine type of file %s' % filename)
+            'mahotas.freeimage: cannot determine type of file {0!s}'.format(filename))
     create_new = True
     read_only = False
     multibitmap = _FI.FreeImage_OpenMultiBitmap(

--- a/mahotas/labeled.py
+++ b/mahotas/labeled.py
@@ -248,7 +248,7 @@ def remove_bordering(labeled, rsize=1, out=None, output=None):
         index[dim] = slice(None,None,None)
     if out is None and output is not None: #pragma: no cover
         import warnings
-        warnings.warn('Using deprecated `output` argument in function `%s`. Please use `out` in the future.' % 'remove_bordering', DeprecationWarning)
+        warnings.warn('Using deprecated `output` argument in function `{0!s}`. Please use `out` in the future.'.format('remove_bordering'), DeprecationWarning)
         out = output
     if out is None:
         out = im.copy()
@@ -374,10 +374,10 @@ def _as_labeled(array, labeled, funcname, inplace='unused'):
     elif not inplace:
         labeled = np.array(labeled, dtype=np.intc)
     elif labeled.dtype != np.intc or not labeled.flags.carray:
-        raise ValueError('mahotas.labeled.%s: labeled must be a C-array of type int' % funcname)
+        raise ValueError('mahotas.labeled.{0!s}: labeled must be a C-array of type int'.format(funcname))
 
     if array.shape != labeled.shape:
-        raise ValueError('mahotas.labeled.%s: `array` is not the same size as `labeled`' % funcname)
+        raise ValueError('mahotas.labeled.{0!s}: `array` is not the same size as `labeled`'.format(funcname))
     return labeled
 
 

--- a/mahotas/stretch.py
+++ b/mahotas/stretch.py
@@ -171,7 +171,7 @@ def as_rgb(r, g, b):
             return c.astype(np.uint8)
         elif c.shape != shape:
             sh = lambda c : (c.shape if c is not None else ' . ')
-            raise ValueError('mahotas.as_rgb: Not all arguments have the same shape. Shapes were : %s' % [sh(r), sh(g), sh(b)])
+            raise ValueError('mahotas.as_rgb: Not all arguments have the same shape. Shapes were : {0!s}'.format([sh(r), sh(g), sh(b)]))
         return stretch(c)
     return np.dstack([s(r), s(g), s(b)])
 

--- a/mahotas/tests/pymorph_copy.py
+++ b/mahotas/tests/pymorph_copy.py
@@ -49,7 +49,7 @@ def limits(f):
     if code == int32: return -2147483647,2147483647
     if code == int64: return -2**63,2**63-1
 
-    raise ValueError('pymorph.limits: does not accept this typecode: %s' % code)
+    raise ValueError('pymorph.limits: does not accept this typecode: {0!s}'.format(code))
 
 def neg(f):
     y = limits(f)[0] + limits(f)[1] - f


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mahotas?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:mahotas?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
